### PR TITLE
Fix error in 'find' example script

### DIFF
--- a/docs/getting-started/03-datascript-queries.md
+++ b/docs/getting-started/03-datascript-queries.md
@@ -82,7 +82,7 @@ These functions will iterate over every single entity of a given type in the gam
 import { std } from "wow/wotlk";
 
 let hearthstone = std.Items.find(item=>item.Name.enGB.get() == 'Hearthstone')
-if(item)
+if(hearthstone)
 {
     console.log('Found hearthstone with id ' + hearthstone.ID)
 }


### PR DESCRIPTION
The if condition should check for the hearthstone variable, not for item.